### PR TITLE
Measured boot

### DIFF
--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -1,0 +1,39 @@
+metadata:
+    name: measured-boot-enabled-PCR7
+    format: "Lava-Test Test Definition 1.0"
+    description: "Checking PCR7 value for measured boot testing"
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - any-linux
+    scope:
+        - functional
+    devices:
+        - qemu
+
+interactive:
+- name: basic-cmds
+  prompts: ['=> ', 'Booting:']
+  script:
+  - command: "virtio scan"
+  - command: ""
+  - command: "ls virtio 0"
+  - command: ""
+  - command: "printenv"
+  - command: ""
+  - command: "efidebug boot add -b 1 BootLedge virtio 0:1 efi/boot/bootaa64.efi -i virtio 0:1 ledge-initramfs.rootfs.cpio.gz -s 'console=ttyAMA0,115200 root=/dev/vda2 rootwait panic=60'"
+  - command: ""
+  - command: "efidebug boot order 1"
+  - command: ""
+  - command: "setenv bootcmd 'bootefi bootmgr'"
+  - command: ""
+  - command: "saveenv"
+  - command: ""
+  - command: "mw.b 0x50000000 a"
+  - command: ""
+  - command: "tpm init"
+  - command: ""
+  - command: "tpm startup TPM2_SU_CLEAR"
+  - command: ""
+  - command: "tpm pcr_extend 7 0x50000000"
+  - command: "bootefi bootmgr"

--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -1,5 +1,5 @@
 metadata:
-    name: measured-boot-enabled-PCR7
+    name: measured-boot-changed-PCR7
     format: "Lava-Test Test Definition 1.0"
     description: "Checking PCR7 value for measured boot testing"
     maintainer:
@@ -15,19 +15,8 @@ interactive:
 - name: basic-cmds
   prompts: ['=> ', 'Booting:']
   script:
-  - command: "virtio scan"
-  - command: ""
-  - command: "ls virtio 0"
   - command: ""
   - command: "printenv"
-  - command: ""
-  - command: "efidebug boot add -b 1 BootLedge virtio 0:1 efi/boot/bootaa64.efi -i virtio 0:1 ledge-initramfs.rootfs.cpio.gz -s 'console=ttyAMA0,115200 root=/dev/vda2 rootwait panic=60'"
-  - command: ""
-  - command: "efidebug boot order 1"
-  - command: ""
-  - command: "setenv bootcmd 'bootefi bootmgr'"
-  - command: ""
-  - command: "saveenv"
   - command: ""
   - command: "mw.b 0x50000000 a"
   - command: ""

--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -36,4 +36,5 @@ interactive:
   - command: "tpm startup TPM2_SU_CLEAR"
   - command: ""
   - command: "tpm pcr_extend 7 0x50000000"
+  - command: ""
   - command: "bootefi bootmgr"

--- a/automated/linux/measured-boot/measured-boot-enable-check-PCR7.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-check-PCR7.yaml
@@ -1,0 +1,16 @@
+metadata:
+    name: measured-boot-enabled-PCR7
+    format: "Lava-Test Test Definition 1.0"
+    description: "Checking PCR7 value for measured boot testing"
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - any-linux
+    scope:
+        - functional
+    devices:
+        - qemu
+run:
+    steps:
+    - sudo tpm2_pcrread sha256:7
+    - sudo shutdown


### PR DESCRIPTION
Creating measured boot test cases for trusted substrate check that measured boot is enabled.

measured-boot-enabled-check-PCR7.yaml checks the value in PCR7 and reboots the device.
measured-boot-enabled-badboot.yaml changes the PCR7 value and afterwards it boots the device with the bad value.

If measured boot from TS is enabled the device should not boot. If it does boot, run check-PCR7 again to make sure PCR7 value has actually changed.